### PR TITLE
Allow dynamic cache prefix

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,8 +25,9 @@ app.use(cache(options))
 ### options
 
 * prefix
-  - type: `String`
+  - type: `String` or `Function`
   - redis key prefix, default is `koa-redis-cache:`
+  - If a function is supplied, its signature should be `function(ctx) {}` and it should return a string to use as the redis key prefix
 * expire
   - type: `Number`
   - redis expire time (second), default is `30 * 60` (30 min)

--- a/index.js
+++ b/index.js
@@ -21,12 +21,10 @@ module.exports = function(options) {
   /**
    * redisClient
    */
-  redisOptions.options = redisOptions.options || {}
-  if(!redisOptions.options.url) {
-    redisOptions.options.port = redisOptions.port || 6379
-    redisOptions.options.host = redisOptions.host || 'localhost'
-  }
-  const redisClient = wrapper(Redis.createClient(redisOptions.options))
+  redisOptions.port = redisOptions.port || 6379
+  redisOptions.host = redisOptions.host || 'localhost'
+  redisOptions.url = redisOptions.url || 'redis://' + redisOptions.host + ':' + redisOptions.port + '/'
+  const redisClient = wrapper(Redis.createClient(redisOptions.url, redisOptions.options))
   redisClient.on('error', (error)=> {
     redisAvailable = false
     onerror(error)

--- a/index.js
+++ b/index.js
@@ -21,9 +21,12 @@ module.exports = function(options) {
   /**
    * redisClient
    */
-  redisOptions.port = redisOptions.port || 6379
-  redisOptions.host = redisOptions.host || 'localhost'
-  const redisClient = wrapper(Redis.createClient(redisOptions.port, redisOptions.host, redisOptions.options))
+  redisOptions.options = redisOptions.options || {}
+  if(!redisOptions.options.url) {
+    redisOptions.options.port = redisOptions.port || 6379
+    redisOptions.options.host = redisOptions.host || 'localhost'
+  }
+  const redisClient = wrapper(Redis.createClient(redisOptions.options))
   redisClient.on('error', (error)=> {
     redisAvailable = false
     onerror(error)

--- a/index.js
+++ b/index.js
@@ -39,7 +39,8 @@ module.exports = function(options) {
     const ctx = this
     const url = ctx.request.url
     const path = ctx.request.path
-    const key = prefix + url
+    const resolvedPrefix = typeof prefix === 'function' ? prefix.call(ctx, ctx) : prefix;
+    const key = resolvedPrefix + url
     const tkey = key + ':type'
     let match = false
     let routeExpire = false

--- a/test/option-prefix.js
+++ b/test/option-prefix.js
@@ -87,4 +87,78 @@ describe('## options - prefix', () => {
         })
     })
   })
+
+  describe('# dynamic prefix', () => {
+    var options = {
+      prefix: function(ctx) {
+        // You won't actually want to directly use user-supplied parameters in cache keys for security reasons
+        return 'dynamic-prefix-user-' + ctx.request.header['x-user'] + '-koa-redis-cache:'
+      }
+    }
+    var app = koa()
+    app.use(cache(options))
+    app.use(function* () {
+      this.body = {
+        name: 'dynamic prefix user ' + this.request.header['x-user']
+      }
+    })
+
+    app = app.listen(3011)
+
+    it('no cache prefix 1', (done) => {
+      request(app)
+        .get('/prefix/json')
+        .set('X-User', 'one')
+        .end((err, res) => {
+          should.not.exist(err)
+          res.status.should.equal(200)
+          res.headers['content-type'].should.equal('application/json; charset=utf-8')
+          should.not.exist(res.headers['x-koa-redis-cache'])
+          res.body.name.should.equal('dynamic prefix user one')
+          done()
+        })
+    })
+
+    it('from cache prefix 1', (done) => {
+      request(app)
+        .get('/prefix/json')
+        .set('X-User', 'one')
+        .end((err, res) => {
+          should.not.exist(err)
+          res.status.should.equal(200)
+          res.headers['content-type'].should.equal('application/json; charset=utf-8')
+          res.headers['x-koa-redis-cache'].should.equal('true')
+          res.body.name.should.equal('dynamic prefix user one')
+          done()
+        })
+    })
+
+    it('no cache prefix 2', (done) => {
+      request(app)
+        .get('/prefix/json')
+        .set('X-User', 'two')
+        .end((err, res) => {
+          should.not.exist(err)
+          res.status.should.equal(200)
+          res.headers['content-type'].should.equal('application/json; charset=utf-8')
+          should.not.exist(res.headers['x-koa-redis-cache'])
+          res.body.name.should.equal('dynamic prefix user two')
+          done()
+        })
+    })
+
+    it('from cache prefix 2', (done) => {
+      request(app)
+        .get('/prefix/json')
+        .set('X-User', 'two')
+        .end((err, res) => {
+          should.not.exist(err)
+          res.status.should.equal(200)
+          res.headers['content-type'].should.equal('application/json; charset=utf-8')
+          res.headers['x-koa-redis-cache'].should.equal('true')
+          res.body.name.should.equal('dynamic prefix user two')
+          done()
+        })
+    })
+  })
 })


### PR DESCRIPTION
Thank you for this! 

I needed dynamic cache prefixes to partition the cache based on a user id. There are obvious security implications here if user supplied parameters are used directly, but in my case I'm using variables from ctx.state set by the app itself.