### PR TITLE
Adding support for returns_buffer options in redis

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,6 +128,7 @@ module.exports = function(options) {
       // buffer
       if (body.length > maxLength) return
       yield redisClient.setex(key, expire, body)
+      yield redisClient.setex(tkey, expire, ctx.response.type)
     } else if (typeof body === 'object' && ctx.response.type === 'application/json') {
       // json
       body = JSON.stringify(body)

--- a/index.js
+++ b/index.js
@@ -101,6 +101,8 @@ module.exports = function(options) {
     if (value) {
       ctx.response.status = 200
       type = (yield redisClient.get(tkey)) || 'text/html'
+      // can happen if user specified return_buffers: true in redis options
+      if (Buffer.isBuffer(type)) type = type.toString()
       ctx.response.set('X-Koa-Redis-Cache', 'true')
       ctx.response.type = type
       ctx.response.body = value
@@ -128,7 +130,6 @@ module.exports = function(options) {
       // buffer
       if (body.length > maxLength) return
       yield redisClient.setex(key, expire, body)
-      yield redisClient.setex(tkey, expire, ctx.response.type)
     } else if (typeof body === 'object' && ctx.response.type === 'application/json') {
       // json
       body = JSON.stringify(body)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-redis-cache",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "a middleware for koa to cache response with redis.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hi,

I was using this module to store generated previews of images and it didn't work out of the box. I had to use the returns_buffer options in redis, but the mime type fetching failed. I now perform a check of the type of 'type' and if buffer, I make a conversion to string. Everything works fine now.

HTH